### PR TITLE
Fix test app

### DIFF
--- a/test-project/bsconfig.json
+++ b/test-project/bsconfig.json
@@ -2,8 +2,8 @@
 	"rootDir": "./",
 	"autoImportComponentScript": true,
 	"files": [
-		"components/*.+(xml|brs|bs)",
-		"source/*.+(xml|brs|bs)",
+		"components/**/*",
+		"source/**/*",
 		"assets/**/*",
 		"manifest"
 	],

--- a/test-project/components/Scene/MainScene/MainScene.xml
+++ b/test-project/components/Scene/MainScene/MainScene.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="MainScene" extends="Scene">
-	<script type="text/brightscript" uri="pkg:/source/roku_modules/rodash.brs" />
+	<script type="text/brightscript" uri="pkg:/source/roku_modules/rodash/rodash.brs" />
 	<interface>
 		<field id="closeApp" type="boolean" alwaysNotify="true" />
 	</interface>


### PR DESCRIPTION
The files array was incorrect for the test app, which also hid the fact that the pkg path to the ropm rodash path was incorrect. both of these fixes then enable the ability to see rodash namespace completions.

![image](https://user-images.githubusercontent.com/2544493/110850480-d3bf8900-827d-11eb-9ed2-63b6f5eddcbd.png)
![image](https://user-images.githubusercontent.com/2544493/110850494-d7eba680-827d-11eb-8360-1fa51eff7fcd.png)
