### PR TITLE
Makes the README the home page of the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,53 @@
       
 
 
+  <section class="readme">
+    <article>
+      <h1>rodash (BETA)</h1>
+<p><a href="https://lodash.com/docs/4.17.15">Lodash</a> inspired <a href="https://developer.roku.com/en-ca/docs/references/brightscript/language/brightscript-language-reference.md">Brightscript</a>/<a href="https://www.npmjs.com/package/ropm">ROPM</a> utility for Roku apps</p>
+<p>Currently supporting 150 utility functions!
+API Documentation coming soon.</p>
+<h2>Important</h2>
+<p>This project is not affiliated with the Tubitv/rodash project.</p>
+<h2>Installation</h2>
+<h3>Using <a href="https://www.npmjs.com/package/ropm">ropm</a></h3>
+<pre class="prettyprint source lang-bash"><code>ropm install rodash@npm:@tkss/rodash
+</code></pre>
+<h2>API Documentation (In Progress)</h2>
+<p><a href="https://tkss-software.github.io/rodash/module-rodash.html">https://tkss-software.github.io/rodash/module-rodash.html</a></p>
+<h2>Usage Examples</h2>
+<h3>Chunk</h3>
+<h4>Brightscript</h4>
+<pre class="prettyprint source"><code>rodash_chunk([&quot;a&quot;, &quot;b&quot;, &quot;c&quot;, &quot;d&quot;], 2)
+</code></pre>
+<h4>Brighterscript</h4>
+<pre class="prettyprint source"><code>rodash.chunk([&quot;a&quot;, &quot;b&quot;, &quot;c&quot;, &quot;d&quot;], 2)
+</code></pre>
+<p>Returns: [[&quot;a&quot;, &quot;b&quot;], [&quot;c&quot;, &quot;d&quot;]]</p>
+<h3>Compact</h3>
+<h4>Brightscript</h4>
+<pre class="prettyprint source"><code>rodash_compact([0, 1, false, 2, &quot;&quot;, 3])
+</code></pre>
+<h4>Brighterscript</h4>
+<pre class="prettyprint source"><code>rodash.compact([0, 1, false, 2, &quot;&quot;, 3])
+</code></pre>
+<p>Returns: [1, 2, 3]</p>
+<h3>Shuffle &amp; Slice</h3>
+<h4>Brightscript</h4>
+<pre class="prettyprint source"><code>rodash_slice(rodash_shuffle([1,2,3,4,5,6,7,8,9,10]), 0, 4)
+</code></pre>
+<h4>Brighterscript</h4>
+<pre class="prettyprint source"><code>rodash.slice(rodash.shuffle([1,2,3,4,5,6,7,8,9,10]), 0, 4)
+</code></pre>
+<p>Returns: [8, 3, 7, 5]</p>
+<h2>Brighterscript Support</h2>
+<p>If imported into a project that leverages the Brighterscript compiler, you can use rodash. lookups with auto-complete.
+<img src="https://user-images.githubusercontent.com/2446955/110862815-30c73900-8296-11eb-8533-4ec1011d7fba.png" alt="image"></p>
+<h2>Development</h2>
+<p>Currently in development</p>
+    </article>
+  </section>
+
 
     
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -5,7 +5,8 @@
   ],
   "source": {
     "include": [
-      "dist/source"
+      "dist/source",
+      "README.md"
     ],
     "includePattern": ".+\\.brs"
   },
@@ -13,7 +14,7 @@
     "referenceTitle": "TKSS rodash API Docs",
     "disableSort": false,
     "collapse": true
-},
+  },
   "opts": {
     "recurse": true
   }


### PR DESCRIPTION
When you run `npm run docs` it adds the current README.md as the home page of the docs.