### PR TITLE
Fixing now() integer issue to return proper Unix epoch in milliseconds.

### DIFF
--- a/src/source/rodash/now.bs
+++ b/src/source/rodash/now.bs
@@ -5,8 +5,8 @@ namespace rodash
   ' @returns {Longinteger} The number of milliseconds that have elapsed since the Unix epoch.
   function now() as Longinteger
     dateObj = rodash.internal.getDateObject()
-    seconds& = dateObj.AsSeconds()
+    seconds& = dateObj.asSeconds()
     milliseconds& = seconds& * 1000
-    return milliseconds& + dateObj.GetMilliseconds()
+    return milliseconds& + dateObj.getMilliseconds()
   end function
 end namespace

--- a/src/source/rodash/now.bs
+++ b/src/source/rodash/now.bs
@@ -2,9 +2,11 @@ namespace rodash
   ' Gets the number of milliseconds that have elapsed since the Unix epoch (1 January 1970 00:00:00 UTC).
   ' @since 0.0.21
   ' @category Date
-  ' @returns {Integer} The number of milliseconds that have elapsed since the Unix epoch.
-  function now() as Integer
+  ' @returns {Longinteger} The number of milliseconds that have elapsed since the Unix epoch.
+  function now() as Longinteger
     dateObj = rodash.internal.getDateObject()
-    return dateObj.asSeconds() + dateObj.getMilliseconds()
+    seconds& = dateObj.AsSeconds()
+    milliseconds& = seconds& * 1000
+    return milliseconds& + dateObj.GetMilliseconds()
   end function
 end namespace

--- a/test-project/source/_date.spec.bs
+++ b/test-project/source/_date.spec.bs
@@ -10,6 +10,7 @@ namespace Tests
     function testNow()
       a = rodash.now()
       b = rodash.now()
+      m.assertTrue(len(a.toStr()), 13)
       diff = b - a
       m.assertTrue(diff <= 1)
       sleep(10)


### PR DESCRIPTION
Hello all!

While using rodash `now()` method I noticed some inconsistencies when comparing to true epoch time in milliseconds.

- `dateObj.AsSeconds()` was not converted to milliseconds before the addition of `dateObj.GetMilliseconds()`
- The returned `Integer` is not adequate for use as it is only capable of handling integers that are 11 digits long, whereas a true millisecond timestamp requires 13 digits.

I changed the function to reflect the changes needed as well as the unit test that tests it, although I am not sure if I did that correctly.

Please let me know if I made a mistake anywhere or if you'd like me to change anything.

Thanks!

P.S. Type declaration with `&` is necessary to coerce `dateObj.asSeconds()` to `Longinteger`, otherwise it's an `Integer` and we're back to the same problem.
