### PR TITLE
Expanding isEmpty method to cover different scenarios.

### DIFF
--- a/src/source/rodash/isEmpty.bs
+++ b/src/source/rodash/isEmpty.bs
@@ -13,8 +13,14 @@ namespace rodash
   ' rodash.isEmpty(invalid) // => true
   ' rodash.isEmpty("Hello") // => false
   function isEmpty(value as Dynamic)
-    if rodash.isInvalid(value) OR rodash.isNumber(value) OR rodash.isBoolean(value) then
+    if rodash.isInvalid(value) then
       return true
+    else if rodash.isNumber(value)
+      return value = 0
+    else if rodash.isBoolean(value)
+      return NOT value
+    else if rodash.isNode(value) OR rodash.isFunction(value)
+      return false
     else
       return value.isEmpty()
     end if

--- a/test-project/source/_lang.spec.bs
+++ b/test-project/source/_lang.spec.bs
@@ -110,8 +110,21 @@ namespace Tests
     @params({ a: 1 }, false)
     @params({}, true)
     @params(Invalid, true)
-    @params(1, true)
+    @params(0, true)
+    @params(1, false)
+    @params(false, true)
+    @params(true, false)
+    @params("NODE", false)
+    @params("FUNCTION", false)
     function _(value = Invalid as Dynamic, matchResult = false as Boolean)
+      if type(value) = "String" OR type(value) = "roString"
+        if value = "NODE"
+          value = CreateObject("roSGNode", "ContentNode")
+        else if value = "FUNCTION"
+          value = function()
+          end function
+        end if
+      end if
       m.assertEqual(rodash.isEmpty(value), matchResult)
     end function
 


### PR DESCRIPTION
I was wondering if changing the `isEmpty` method was acceptable.  I know it modifies the validation behavior of numbers and booleans, so I understand if this change is not possible.  

Thanks!